### PR TITLE
Hide note status bar when not use

### DIFF
--- a/lib/assets/summernote-lite-dark.css
+++ b/lib/assets/summernote-lite-dark.css
@@ -2,7 +2,7 @@
 	background: #121212 !important;
 }
 .panel-heading, .note-toolbar, .note-statusbar {
-	display:none;
+	display: none;
 }
 input, select, textarea, .CodeMirror, .note-editable, [class^="note-icon-"], .caseConverter-toggle,
 button > b, button > code, button > var, button > kbd, button > samp, button > small, button > ins, button > del, button > p, button > i {

--- a/lib/assets/summernote-lite-dark.css
+++ b/lib/assets/summernote-lite-dark.css
@@ -2,7 +2,7 @@
 	background: #121212 !important;
 }
 .panel-heading, .note-toolbar, .note-statusbar {
-	background: #343434 !important;
+	display:none;
 }
 input, select, textarea, .CodeMirror, .note-editable, [class^="note-icon-"], .caseConverter-toggle,
 button > b, button > code, button > var, button > kbd, button > samp, button > small, button > ins, button > del, button > p, button > i {

--- a/lib/assets/summernote-lite.min.css
+++ b/lib/assets/summernote-lite.min.css
@@ -1059,6 +1059,7 @@ a.note-dropdown-item,a.note-dropdown-item:hover {
   border-bottom-left-radius: 4px;
   border-bottom-right-radius: 4px;
   border-top: 1px solid #ddd;
+  display: none;
 }
 
 .note-editor.note-airframe .note-statusbar .note-resizebar,.note-editor.note-frame .note-statusbar .note-resizebar {
@@ -1066,16 +1067,19 @@ a.note-dropdown-item,a.note-dropdown-item:hover {
   height: 9px;
   width: 100%;
   cursor: ns-resize;
+  display: none;
 }
 
 .note-editor.note-airframe .note-statusbar .note-resizebar .note-icon-bar,.note-editor.note-frame .note-statusbar .note-resizebar .note-icon-bar {
   width: 20px;
   margin: 1px auto;
   border-top: 1px solid #a9a9a9;
+  display: none;
 }
 
 .note-editor.note-airframe .note-statusbar.locked .note-resizebar,.note-editor.note-frame .note-statusbar.locked .note-resizebar {
   cursor: default;
+  display: none;
 }
 
 .note-editor.note-airframe .note-statusbar.locked .note-resizebar .note-icon-bar,.note-editor.note-frame .note-statusbar.locked .note-resizebar .note-icon-bar {


### PR DESCRIPTION
Default
 
https://user-images.githubusercontent.com/99852347/224772672-5c1ca9c2-595f-4e6a-b81b-0ade33ca2fc5.mov

In our project we aren't using it, We update to remove it


https://user-images.githubusercontent.com/99852347/224772921-385c4e13-5097-4616-a209-f4c07566070b.mov

