### PR TITLE
Fix some text style not work on Firefox

### DIFF
--- a/lib/assets/summernote-lite.min.css
+++ b/lib/assets/summernote-lite.min.css
@@ -934,6 +934,7 @@ a.note-dropdown-item,a.note-dropdown-item:hover {
 }
 
 .note-editor.note-airframe .note-editing-area .note-editable,.note-editor.note-frame .note-editing-area .note-editable {
+  padding: 10px 10px 0px 10px;
   overflow: auto;
   word-wrap: break-word;
 }

--- a/lib/src/html_editor_controller_unsupported.dart
+++ b/lib/src/html_editor_controller_unsupported.dart
@@ -81,6 +81,9 @@ class HtmlEditorController {
   /// A function to quickly call a document.execCommand function in a readable format
   void execCommand(String command, {String? argument}) {}
 
+  /// A function to quickly call a Summernote API function in a readable format
+  void execSummernoteAPI(String nameAPI, {String? value}) {}
+
   /// A function to execute JS passed as a [WebScript] to the editor. This should
   /// only be used on Flutter Web.
   Future<dynamic> evaluateJavascriptWeb(String name,

--- a/lib/src/html_editor_controller_web.dart
+++ b/lib/src/html_editor_controller_web.dart
@@ -246,6 +246,16 @@ class HtmlEditorController extends unsupported.HtmlEditorController {
     });
   }
 
+  /// A function to quickly call a Summernote API function in a readable format
+  @override
+  void execSummernoteAPI(String nameAPI, {String? value}) {
+    _evaluateJavascriptWeb(data: {
+      'type': 'toIframe: execSummernoteAPI',
+      'nameAPI': nameAPI,
+      'value': value
+    });
+  }
+
   /// A function to execute JS passed as a [WebScript] to the editor. This should
   /// only be used on Flutter Web.
   @override

--- a/lib/src/widgets/html_editor_widget_web.dart
+++ b/lib/src/widgets/html_editor_widget_web.dart
@@ -424,6 +424,8 @@ class _HtmlEditorWidgetWebState extends State<HtmlEditorWidget> {
           }
         }
         
+        ${JavascriptUtils.jsDetectBrowser}
+        
         function onSelectionChange() {
           let {anchorNode, anchorOffset, focusNode, focusOffset} = document.getSelection();
           var isBold = false;
@@ -472,6 +474,12 @@ class _HtmlEditorWidgetWebState extends State<HtmlEditorWidget> {
                backColor = document.queryCommandValue('backColor');
             }
             fontName = document.queryCommandValue('fontName');
+          }
+          const browserName = getBrowserName();
+          console.log('browserName: ' + browserName)
+          if (browserName === "Firefox") {
+            backColor = \$(focusNode.parentNode).css('background-color');
+            console.log('backColor-Firefox: ' + backColor);
           }
           var message = {
             'view': "$createdViewId", 

--- a/lib/src/widgets/html_editor_widget_web.dart
+++ b/lib/src/widgets/html_editor_widget_web.dart
@@ -338,6 +338,16 @@ class _HtmlEditorWidgetWebState extends State<HtmlEditorWidget> {
                   }
                 }
               }
+              if (data["type"].includes("execSummernoteAPI")) {
+                var nameAPI = data["nameAPI"];
+                var value = data["value"];
+                console.log("nameAPI: " + nameAPI + " | value: " + value);
+                if (value === null) {
+                  \$('#summernote-2').summernote(nameAPI);
+                } else {
+                  \$('#summernote-2').summernote(nameAPI, value);
+                }
+              }
               if (data["type"].includes("changeListStyle")) {
                 var \$focusNode = \$(window.getSelection().focusNode);
                 var \$parentList = \$focusNode.closest("div.note-editable ol, div.note-editable ul");

--- a/lib/src/widgets/toolbar_widget.dart
+++ b/lib/src/widgets/toolbar_widget.dart
@@ -177,28 +177,65 @@ class ToolbarWidgetState extends State<ToolbarWidget> {
     }
     debugPrint('ToolbarWidget::updateToolbar::colorList: $colorList');
     //update the fore/back selected color if necessary
-    if (colorList[0] != null && colorList[0]!.isNotEmpty && colorList[0]!.startsWith('rgb')) {
+    final foregroundColor = colorList[0];
+    if (foregroundColor != null && foregroundColor.isNotEmpty) {
       setState(mounted, this.setState, () {
-        var rgb = colorList[0]!.replaceAll('rgb(', '').replaceAll(')', '');
-        var rgbList = rgb.split(', ');
-        _foreColorSelected = Color.fromRGBO(int.parse(rgbList[0]),
-            int.parse(rgbList[1]), int.parse(rgbList[2]), 1);
+        if (foregroundColor.startsWith('rgb(')) {
+          var rgb = foregroundColor.replaceAll('rgb(', '').replaceAll(')', '');
+          var rgbList = rgb.split(', ');
+          if (rgbList.length >= 3) {
+            _foreColorSelected = Color.fromRGBO(
+              int.parse(rgbList[0]),
+              int.parse(rgbList[1]),
+              int.parse(rgbList[2]),
+              1
+            );
+          }
+        } else if (foregroundColor.startsWith('rgba(')) {
+          var rgba = foregroundColor.replaceAll('rgba(', '').replaceAll(')', '');
+          var rgbaList = rgba.split(', ');
+          if (rgbaList.length >= 4) {
+            _foreColorSelected = Color.fromRGBO(
+              int.parse(rgbaList[0]),
+              int.parse(rgbaList[1]),
+              int.parse(rgbaList[2]),
+              double.parse(rgbaList[3])
+            );
+          }
+        }
       });
     } else {
       setState(mounted, this.setState, () {
         _foreColorSelected = Colors.black;
       });
     }
-    if (colorList[1] != null && colorList[1]!.isNotEmpty && colorList[1]!.startsWith('rgb')) {
+
+    final backgroundColor = colorList[1];
+    if (backgroundColor != null && backgroundColor.isNotEmpty) {
       setState(mounted, this.setState, () {
-        var rgb = colorList[1]!.replaceAll('rgb(', '').replaceAll(')', '');
-        var rgbList = rgb.split(', ');
-        _backColorSelected = Color.fromRGBO(
-          int.parse(rgbList[0]),
-          int.parse(rgbList[1]),
-          int.parse(rgbList[2]),
-          1
-        );
+        if (backgroundColor.startsWith('rgb(')) {
+          var rgb = backgroundColor.replaceAll('rgb(', '').replaceAll(')', '');
+          var rgbList = rgb.split(', ');
+          if (rgbList.length >= 3) {
+            _backColorSelected = Color.fromRGBO(
+              int.parse(rgbList[0]),
+              int.parse(rgbList[1]),
+              int.parse(rgbList[2]),
+              1
+            );
+          }
+        } else if (backgroundColor.startsWith('rgba(')) {
+          var rgba = backgroundColor.replaceAll('rgba(', '').replaceAll(')', '');
+          var rgbaList = rgba.split(', ');
+          if (rgbaList.length >= 4) {
+            _backColorSelected = Color.fromRGBO(
+              int.parse(rgbaList[0]),
+              int.parse(rgbaList[1]),
+              int.parse(rgbaList[2]),
+              double.parse(rgbaList[3])
+            );
+          }
+        }
       });
     } else {
       setState(mounted, this.setState, () {

--- a/lib/utils/javascript_utils.dart
+++ b/lib/utils/javascript_utils.dart
@@ -38,4 +38,42 @@ class JavascriptUtils {
     console.log('currentDirection: ' + currentDirection);
     nodeEditor.style.direction = currentDirection.toString();
   ''';
+
+  static const String jsDetectBrowser = '''
+    function getBrowserName() {
+      // Opera 8.0+
+      if ((window.opr && window.opr.addons)
+        || window.opera
+        || navigator.userAgent.indexOf(' OPR/') >= 0) {
+        return 'Opera';
+      }
+    
+      // Firefox 1.0+
+      if (/Firefox|FxiOS/.test(navigator.userAgent)) {
+        return 'Firefox';
+      }
+    
+      // Safari 3.0+ "[object HTMLElementConstructor]"
+      if (/constructor/i.test(window.HTMLElement) || (function (p) {
+        return p.toString() === '[object SafariRemoteNotification]';
+      })(!window['safari'])) {
+        return 'Safari';
+      }
+    
+      // Internet Explorer 6-11
+      if (/* @cc_on!@*/false || document.documentMode) {
+        return 'Internet Explorer';
+      }
+    
+      // Edge 20+
+      if (!(document.documentMode) && window.StyleMedia) {
+        return 'Microsoft Edge';
+      }
+      
+      // Chrome
+      if (window.chrome) {
+        return 'Chrome';
+      }
+    }
+  ''';
 }


### PR DESCRIPTION
### Changed

- Add `SummerNoteAPI` to support format text style
- Fix `document.queryCommandValue('hiliteColor')` and  `document.queryCommandValue('backColor')` not work on Firefox
- Add `left/right/top` padding default for editor