### PR TITLE
Avoid `onBlur` method called twice when editor loses focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.1.3] - 2025-01-07
+* Fix drag & drop files
+* Avoid `onBlur` being called twice when editor loses focus
+
 ## [3.1.2] - 2024-11-20
 * Let editor decide its own height instead of calculating html content
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -119,7 +119,7 @@ class _HtmlEditorExampleState extends State<HtmlEditorExample> {
                   debugPrint('enter/return pressed');
                 }, onFocus: () {
                   debugPrint('editor focused');
-                }, onBlur: () {
+                }, onUnFocus: () {
                   debugPrint('editor unfocused');
                 }, onBlurCodeview: () {
                   debugPrint('codeview either focused or unfocused');

--- a/lib/src/widgets/html_editor_widget_mobile.dart
+++ b/lib/src/widgets/html_editor_widget_mobile.dart
@@ -601,10 +601,10 @@ class _HtmlEditorWidgetMobileState extends State<HtmlEditorWidget> {
           });
         """);
     }
-    if (c.onBlur != null) {
+    if (c.onUnFocus != null) {
       widget.controller.editorController!.evaluateJavascript(source: """
           \$('#summernote-2').on('summernote.blur', function() {
-            window.flutter_inappwebview.callHandler('onBlur', 'fired');
+            window.flutter_inappwebview.callHandler('onUnFocus', 'fired');
           });
         """);
     }
@@ -697,11 +697,11 @@ class _HtmlEditorWidgetMobileState extends State<HtmlEditorWidget> {
             c.onFocus!.call();
           });
     }
-    if (c.onBlur != null) {
+    if (c.onUnFocus != null) {
       widget.controller.editorController!.addJavaScriptHandler(
-          handlerName: 'onBlur',
+          handlerName: 'onUnFocus',
           callback: (_) {
-            c.onBlur!.call();
+            c.onUnFocus!.call();
           });
     }
     if (c.onBlurCodeview != null) {

--- a/lib/src/widgets/html_editor_widget_web.dart
+++ b/lib/src/widgets/html_editor_widget_web.dart
@@ -63,7 +63,6 @@ class _HtmlEditorWidgetWebState extends State<HtmlEditorWidget> {
   StreamSubscription<html.MessageEvent>? _editorJSListener;
   StreamSubscription<html.MessageEvent>? _summernoteOnLoadListener;
   static const String _summernoteLoadedMessage = '_HtmlEditorWidgetWebState::summernoteLoaded';
-  final _focusNode = FocusNode();
 
   @override
   void initState() {
@@ -674,9 +673,7 @@ class _HtmlEditorWidgetWebState extends State<HtmlEditorWidget> {
       ],
     );
 
-    return Focus(
-      focusNode: _focusNode,
-      child: child);
+    return child;
   }
 
   /// Adds the callbacks the user set into JavaScript
@@ -814,7 +811,6 @@ class _HtmlEditorWidgetWebState extends State<HtmlEditorWidget> {
           c.onEnter!.call();
         }
         if (data['type'].contains('onFocus')) {
-          _focusNode.requestFocus();
           c.onFocus!.call();
         }
         if (data['type'].contains('onUnFocus')) {
@@ -983,7 +979,6 @@ class _HtmlEditorWidgetWebState extends State<HtmlEditorWidget> {
   void dispose() {
     _editorJSListener?.cancel();
     _summernoteOnLoadListener?.cancel();
-    _focusNode.dispose();
     super.dispose();
   }
 }

--- a/lib/src/widgets/html_editor_widget_web.dart
+++ b/lib/src/widgets/html_editor_widget_web.dart
@@ -2,7 +2,6 @@ export 'dart:html';
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:html';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -61,8 +60,8 @@ class _HtmlEditorWidgetWebState extends State<HtmlEditorWidget> {
 
   final _jsonEncoder = const JsonEncoder();
 
-  StreamSubscription<MessageEvent>? _editorJSListener;
-  StreamSubscription<MessageEvent>? _summernoteOnLoadListener;
+  StreamSubscription<html.MessageEvent>? _editorJSListener;
+  StreamSubscription<html.MessageEvent>? _summernoteOnLoadListener;
   static const String _summernoteLoadedMessage = '_HtmlEditorWidgetWebState::summernoteLoaded';
   final _focusNode = FocusNode();
 
@@ -718,10 +717,10 @@ class _HtmlEditorWidgetWebState extends State<HtmlEditorWidget> {
           });\n
         """;
     }
-    if (c.onBlur != null) {
+    if (c.onUnFocus != null) {
       callbacks =
           """$callbacks          \$('#summernote-2').on('summernote.blur', function() {
-            window.parent.postMessage(JSON.stringify({"view": "$createdViewId", "type": "toDart: onBlur"}), "*");
+            window.parent.postMessage(JSON.stringify({"view": "$createdViewId", "type": "toDart: onUnFocus"}), "*");
           });\n
         """;
     }
@@ -818,8 +817,8 @@ class _HtmlEditorWidgetWebState extends State<HtmlEditorWidget> {
           _focusNode.requestFocus();
           c.onFocus!.call();
         }
-        if (data['type'].contains('onBlur')) {
-          c.onBlur!.call();
+        if (data['type'].contains('onUnFocus')) {
+          c.onUnFocus!.call();
         }
         if (data['type'].contains('onBlurCodeview')) {
           c.onBlurCodeview!.call();

--- a/lib/utils/callbacks.dart
+++ b/lib/utils/callbacks.dart
@@ -12,7 +12,7 @@ class Callbacks {
     this.onDialogShown,
     this.onEnter,
     this.onFocus,
-    this.onBlur,
+    this.onUnFocus,
     this.onBlurCodeview,
     this.onImageLinkInsert,
     this.onImageUpload,
@@ -93,7 +93,7 @@ class Callbacks {
   /// the webview or dismissing the keyboard does not trigger this callback.
   /// This callback will only be triggered if the user taps on an empty space
   /// in the toolbar or switches the view mode of the editor.
-  void Function()? onBlur;
+  void Function()? onUnFocus;
 
   /// Called whenever the code view either gains or loses focus (the Summernote
   /// docs say this will only be called when the code view loses focus but

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: html_editor_enhanced
 description: HTML rich text editor for Android, iOS, and Web, using the Summernote library.
   Enhanced with highly customizable widget-based controls, bug fixes, callbacks, dark mode, and more.
-version: 3.1.2
+version: 3.1.3
 homepage: https://github.com/tneotia/html-editor-enhanced
 
 environment:


### PR DESCRIPTION
## Issue

- `onBlur` method called twice when editor loses focus

<img width="486" alt="Screenshot 2024-09-30 at 09 52 23" src="https://github.com/user-attachments/assets/c02cde4a-99d7-4694-bcd7-237afd228a18">

## Root cause

Duplicate start name in two functions `onBlur` & `onBlurCodeview` causes string `contain` checker to misunderstand


## Resolved

<img width="486" alt="Screenshot 2024-09-30 at 09 52 47" src="https://github.com/user-attachments/assets/95693351-903c-4864-83a0-ce90f29b0453">
