### PR TITLE
Fix cannot break `quote/code` tag when press Enter key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.1.4] - 2025-03-12
+* Support flutter version `3.24.5`
+* Fix cannot break `quote/code` tag when press Enter key
+
 ## [3.1.3] - 2025-01-07
 * Fix drag & drop files
 * Avoid `onBlur` being called twice when editor loses focus

--- a/lib/assets/summernote-lite-dark.css
+++ b/lib/assets/summernote-lite-dark.css
@@ -2,7 +2,7 @@
 	background: #121212 !important;
 }
 .panel-heading, .note-toolbar, .note-statusbar {
-	display: none;
+	background: #343434 !important;
 }
 input, select, textarea, .CodeMirror, .note-editable, [class^="note-icon-"], .caseConverter-toggle,
 button > b, button > code, button > var, button > kbd, button > samp, button > small, button > ins, button > del, button > p, button > i {

--- a/lib/assets/summernote-lite.min.css
+++ b/lib/assets/summernote-lite.min.css
@@ -1059,8 +1059,6 @@ a.note-dropdown-item,a.note-dropdown-item:hover {
   background-color: #f5f5f5;
   border-bottom-left-radius: 4px;
   border-bottom-right-radius: 4px;
-  border-top: 1px solid #ddd;
-  display: none;
 }
 
 .note-editor.note-airframe .note-statusbar .note-resizebar,.note-editor.note-frame .note-statusbar .note-resizebar {
@@ -1075,12 +1073,10 @@ a.note-dropdown-item,a.note-dropdown-item:hover {
   width: 20px;
   margin: 1px auto;
   border-top: 1px solid #a9a9a9;
-  display: none;
 }
 
 .note-editor.note-airframe .note-statusbar.locked .note-resizebar,.note-editor.note-frame .note-statusbar.locked .note-resizebar {
   cursor: default;
-  display: none;
 }
 
 .note-editor.note-airframe .note-statusbar.locked .note-resizebar .note-icon-bar,.note-editor.note-frame .note-statusbar.locked .note-resizebar .note-icon-bar {

--- a/lib/src/widgets/html_editor_widget_web.dart
+++ b/lib/src/widgets/html_editor_widget_web.dart
@@ -88,12 +88,6 @@ class _HtmlEditorWidgetWebState extends State<HtmlEditorWidget> {
     var headString = '';
     var summernoteCallbacks = '''callbacks: {
         onKeydown: function(e) {
-            if (e.keyCode === 13) { /* ENTER */
-              const editor = querySelector('.note-editable');
-              editor.blur();
-              editor.focus();
-            }
-
             var chars = \$(".note-editable").text();
             var totalChars = chars.length;
             ${widget.htmlEditorOptions.characterLimit != null ? '''allowedKeys = (
@@ -114,6 +108,7 @@ class _HtmlEditorWidgetWebState extends State<HtmlEditorWidget> {
             if (!allowedKeys && \$(e.target).text().length >= ${widget.htmlEditorOptions.characterLimit}) {
                 e.preventDefault();
             }''' : ''}
+            ${JavascriptUtils.jsHandleOnKeyDown}
             window.parent.postMessage(JSON.stringify({"view": "$createdViewId", "type": "toDart: characterCount", "totalChars": totalChars}), "*");
         },
     ''';

--- a/lib/utils/icon_utils.dart
+++ b/lib/utils/icon_utils.dart
@@ -1,5 +1,7 @@
 
 class IconUtils {
+  IconUtils._();
+
   static const String chevronUpSVGIconUrlEncoded = '''
     url("data:image/svg+xml,%3Csvg class='chevron-down' width='20' height='20' viewBox='0 0 20 20' fill='none' xmlns='http://www.w3.org/2000/svg' %3E%3Cpath d='M14.5352 11.9709C14.8347 12.2276 15.2857 12.193 15.5424 11.8934C15.7991 11.5939 15.7644 11.143 15.4649 10.8863L10.4649 6.60054C10.1974 6.37127 9.8027 6.37127 9.53521 6.60054L4.53521 10.8863C4.23569 11.143 4.201 11.5939 4.45773 11.8934C4.71446 12.193 5.16539 12.2276 5.46491 11.9709L10.0001 8.08364L14.5352 11.9709Z' fill='%23AEAEC0' /%3E%3C/svg%3E")
   ''';

--- a/lib/utils/icon_utils.dart
+++ b/lib/utils/icon_utils.dart
@@ -1,6 +1,6 @@
 
 class IconUtils {
-  IconUtils._();
+  const IconUtils._();
 
   static const String chevronUpSVGIconUrlEncoded = '''
     url("data:image/svg+xml,%3Csvg class='chevron-down' width='20' height='20' viewBox='0 0 20 20' fill='none' xmlns='http://www.w3.org/2000/svg' %3E%3Cpath d='M14.5352 11.9709C14.8347 12.2276 15.2857 12.193 15.5424 11.8934C15.7991 11.5939 15.7644 11.143 15.4649 10.8863L10.4649 6.60054C10.1974 6.37127 9.8027 6.37127 9.53521 6.60054L4.53521 10.8863C4.23569 11.143 4.201 11.5939 4.45773 11.8934C4.71446 12.193 5.16539 12.2276 5.46491 11.9709L10.0001 8.08364L14.5352 11.9709Z' fill='%23AEAEC0' /%3E%3C/svg%3E")

--- a/lib/utils/javascript_utils.dart
+++ b/lib/utils/javascript_utils.dart
@@ -2,6 +2,7 @@
 import 'package:html_editor_enhanced/utils/icon_utils.dart';
 
 class JavascriptUtils {
+  JavascriptUtils._();
 
   static const String jsHandleInsertSignature = '''
     const signatureNode = document.querySelector('.note-editable > .tmail-signature');
@@ -202,5 +203,31 @@ class JavascriptUtils {
     \$('#summernote-2').on('summernote.keyup', function(_, e) {
       updateTags();
     });
+  ''';
+
+  static const String jsHandleOnKeyDown = '''
+      if (e.which === 13) { // Press "Enter"
+          setTimeout(() => {
+              let selection = window.getSelection();
+              if (selection.rangeCount > 0) {
+                  let range = selection.getRangeAt(0);
+                  let node = range.commonAncestorContainer;
+                  
+                  // If the node is a text node, get its parent element
+                  if (node.nodeType === 3) { 
+                      node = node.parentElement;
+                  }
+  
+                  // Check if the node has no height (empty line after Enter)
+                  if (node && node.getBoundingClientRect().height === 0) {
+                      node = node.nextElementSibling || node.parentElement;
+                  }
+  
+                  if (node) {
+                      node.scrollIntoView({ behavior: "smooth", block: "nearest" });
+                  }
+              }
+          }, 50); // Increase delay to 50ms to allow DOM updates
+      }
   ''';
 }

--- a/lib/utils/javascript_utils.dart
+++ b/lib/utils/javascript_utils.dart
@@ -2,7 +2,7 @@
 import 'package:html_editor_enhanced/utils/icon_utils.dart';
 
 class JavascriptUtils {
-  JavascriptUtils._();
+  const JavascriptUtils._();
 
   static const String jsHandleInsertSignature = '''
     const signatureNode = document.querySelector('.note-editable > .tmail-signature');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: html_editor_enhanced
 description: HTML rich text editor for Android, iOS, and Web, using the Summernote library.
   Enhanced with highly customizable widget-based controls, bug fixes, callbacks, dark mode, and more.
-version: 3.1.3
+version: 3.1.4
 homepage: https://github.com/tneotia/html-editor-enhanced
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: html_editor_enhanced
 description: HTML rich text editor for Android, iOS, and Web, using the Summernote library.
   Enhanced with highly customizable widget-based controls, bug fixes, callbacks, dark mode, and more.
-version: 3.1.4
+version: 3.1.5
 homepage: https://github.com/tneotia/html-editor-enhanced
 
 environment:


### PR DESCRIPTION
## Root cause

By default `Summernote` has supported proper line breaks for `Quote/Code` tags when pressing `Enter` or `Shift + Enter`. But when integrating into the `TwakeMail` project, to be compatible with the interface, we accidentally hide the `CSS`, overriding the `onKeydown` event, affecting the way `Summernote` implemented it.

## Solution

- Revert the necessary `CSS`, but maintain compatibility with `TwakeMail`.
- Add `onKeydown` event handling logic to properly wrap the tags

## Resolved


https://github.com/user-attachments/assets/31f05298-9aa9-49ce-8d0f-a599125ab77d

