### PR TITLE
Support cache asset offline

### DIFF
--- a/lib/html_editor.dart
+++ b/lib/html_editor.dart
@@ -8,6 +8,8 @@ export 'package:html_editor_enhanced/utils/file_upload_model.dart';
 export 'package:html_editor_enhanced/utils/options.dart';
 export 'package:html_editor_enhanced/utils/utils.dart'
     hide setState, intersperse, getRandString;
+export 'package:html_editor_enhanced/utils/html_editor_utils.dart';
+export 'package:html_editor_enhanced/utils/html_editor_constants.dart';
 
 export 'package:html_editor_enhanced/src/html_editor_unsupported.dart'
     if (dart.library.html) 'package:html_editor_enhanced/src/html_editor_web.dart'

--- a/lib/utils/html_editor_constants.dart
+++ b/lib/utils/html_editor_constants.dart
@@ -1,0 +1,11 @@
+
+class HtmlEditorConstants {
+  HtmlEditorConstants._();
+
+  static const String summernoteHtmlAssetPath = 'packages/html_editor_enhanced/assets/summernote-no-plugins.html';
+  static const String jqueryAssetPath = 'packages/html_editor_enhanced/assets/jquery.min.js';
+  static const String summernoteCSSAssetPath = 'packages/html_editor_enhanced/assets/summernote-lite.min.css';
+  static const String summernoteJSAssetPath = 'packages/html_editor_enhanced/assets/summernote-lite-v2.min.js';
+  static const String summernoteFontEOTAssetPath = 'assets/packages/html_editor_enhanced/assets/font/summernote.eot';
+  static const String summernoteFontTTFAssetPath = 'assets/packages/html_editor_enhanced/assets/font/summernote.ttf';
+}

--- a/lib/utils/html_editor_utils.dart
+++ b/lib/utils/html_editor_utils.dart
@@ -1,0 +1,20 @@
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class HtmlEditorUtils {
+  static HtmlEditorUtils? _instance;
+
+  HtmlEditorUtils._();
+
+  factory HtmlEditorUtils() => _instance ??= HtmlEditorUtils._();
+
+  Future<String> loadAssetAsString(String path) async {
+    try {
+      return rootBundle.loadString(path);
+    } catch (e) {
+      debugPrint('HtmlEditorUtils::loadAssetAsString:Exception = $e');
+      return '';
+    }
+  }
+}

--- a/lib/utils/options.dart
+++ b/lib/utils/options.dart
@@ -28,6 +28,7 @@ class HtmlEditorOptions {
     this.customBodyCssStyle = '',
     this.customInternalCSS = '',
     this.disableDragAndDrop = false,
+    this.cacheHTMLAssetOffline = false,
   });
 
   /// The editor will automatically adjust its height when the keyboard is active
@@ -136,6 +137,9 @@ class HtmlEditorOptions {
 
   /// Disable drag and drop
   final bool disableDragAndDrop;
+
+  /// Inject JS/CSS content directly into HTML to support loading assets when in offline mode
+  final bool cacheHTMLAssetOffline;
 }
 
 /// Options that modify the toolbar and its behavior


### PR DESCRIPTION
## Why?

When in offline mode, we cannot load assets (`scripts, css,..`) in html

## Solution 

Directly download the contents of `script, css,..` files and assign them to html

## Performance

Because we have to load all the content of the `scripts, css,...` files, the size of the html file will increase. BUT not significantly because the `scripts, css,..` files are only `~300` KB in total, which is still okay in most cases.


