### PR TITLE
Image inserted below signature on Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [3.2.0] - 2025-07-22
+* Fix image inserted below signature on Safari
+
 ## [3.1.9] - 2025-06-24
 * Fix duplicate signature button when inserting image
 

--- a/lib/src/widgets/html_editor_widget_web.dart
+++ b/lib/src/widgets/html_editor_widget_web.dart
@@ -240,6 +240,8 @@ class _HtmlEditorWidgetWebState extends State<HtmlEditorWidget> {
     }
     var summernoteScripts = """
       <script type="text/javascript">
+        let editorHasBeenFocused = false;
+      
         \$(document).ready(function () {
           \$('#summernote-2').summernote({
             placeholder: "${widget.htmlEditorOptions.hint}",
@@ -255,6 +257,10 @@ class _HtmlEditorWidgetWebState extends State<HtmlEditorWidget> {
           
           \$('#summernote-2').on('summernote.change', function(_, contents, \$editable) {
             window.parent.postMessage(JSON.stringify({"view": "$createdViewId", "type": "toDart: onChangeContent", "contents": contents}), "*");
+          });
+          
+          \$('#summernote-2').on('summernote.focus', function() {
+            editorHasBeenFocused = true;
           });
         });
        

--- a/lib/utils/javascript_utils.dart
+++ b/lib/utils/javascript_utils.dart
@@ -135,39 +135,16 @@ class JavascriptUtils {
 
   static const String jsDetectBrowser = '''
     function getBrowserName() {
-      // Opera 8.0+
-      if ((window.opr && window.opr.addons)
-        || window.opera
-        || navigator.userAgent.indexOf(' OPR/') >= 0) {
-        return 'Opera';
-      }
+      const ua = navigator.userAgent;
+
+      if (ua.includes('OPR') || ua.includes('Opera')) return 'Opera';
+      if (ua.includes('Edg')) return 'Microsoft Edge';
+      if (ua.includes('Chrome') && !ua.includes('Edg') && !ua.includes('OPR')) return 'Chrome';
+      if (ua.includes('Safari') && !ua.includes('Chrome') && !ua.includes('Edg') && !ua.includes('OPR')) return 'Safari';
+      if (ua.includes('Firefox')) return 'Firefox';
+      if (ua.includes('Trident') || ua.includes('MSIE')) return 'Internet Explorer';
     
-      // Firefox 1.0+
-      if (/Firefox|FxiOS/.test(navigator.userAgent)) {
-        return 'Firefox';
-      }
-    
-      // Safari 3.0+ "[object HTMLElementConstructor]"
-      if (/constructor/i.test(window.HTMLElement) || (function (p) {
-        return p.toString() === '[object SafariRemoteNotification]';
-      })(!window['safari'])) {
-        return 'Safari';
-      }
-    
-      // Internet Explorer 6-11
-      if (/* @cc_on!@*/false || document.documentMode) {
-        return 'Internet Explorer';
-      }
-    
-      // Edge 20+
-      if (!(document.documentMode) && window.StyleMedia) {
-        return 'Microsoft Edge';
-      }
-      
-      // Chrome
-      if (window.chrome) {
-        return 'Chrome';
-      }
+      return 'Unknown';
     }
   ''';
 
@@ -250,7 +227,13 @@ class JavascriptUtils {
           return;
         }
       }
-      \$('#summernote-2').summernote('pasteHTML', imgSource);
+
+      const browserName = getBrowserName();
+      if ((browserName === 'Safari' || browserName === 'Firefox') && !editorHasBeenFocused) {
+        safePasteHTML(imgSource);
+      } else {
+        \$('#summernote-2').summernote('pasteHTML', imgSource);
+      }
     }
     
     function isRangeOutsideSignatureButton() {
@@ -267,6 +250,24 @@ class JavascriptUtils {
       } catch (error) {
         return true;
       }
+    }
+    
+    function safePasteHTML(htmlToInsert) {
+      const nodeEditor = document.querySelector('.note-editable');
+      if (nodeEditor) {
+        const signatureNode = document.querySelector('.note-editable > div.tmail-signature');
+        console.log('signatureNode:: signatureNode');
+        const imageContainer = document.createElement('div');
+        imageContainer.innerHTML = htmlToInsert;
+        if (signatureNode) {
+          nodeEditor.insertBefore(imageContainer, signatureNode);
+        } else {
+          nodeEditor.appendChild(imageContainer);
+        }
+        return;
+      }
+      
+      \$('#summernote-2').summernote('pasteHTML', imgSource);
     }
   ''';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: html_editor_enhanced
 description: HTML rich text editor for Android, iOS, and Web, using the Summernote library.
   Enhanced with highly customizable widget-based controls, bug fixes, callbacks, dark mode, and more.
-version: 3.1.9
+version: 3.2.0
 homepage: https://github.com/tneotia/html-editor-enhanced
 
 environment:


### PR DESCRIPTION
## Issue

Image inserted below signature on Safari

## Root cause

On Safari, if the editor `(.note-editable)` has never been focused, `window.getSelection()` returns no valid range `(rangeCount === 0)`. As a result, `pasteHTML` doesn't know where to insert the content → the image is inserted at the end

## Resolved


https://github.com/user-attachments/assets/12120c7f-b5c0-4eaa-9e5d-e02f310cd765

