### PR TITLE
Fix `line-height` is auto changed when copy/paste or drag/drop from `odt` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.2.2] - 2025-08-04
+
+- Fix `line-height` is auto changed when copy/paste or drag/drop text from `odt` file
+
 ## [3.2.1] - 2025-07-29
 
 - Support flutter version `3.27.4`

--- a/lib/src/widgets/html_editor_widget_web.dart
+++ b/lib/src/widgets/html_editor_widget_web.dart
@@ -215,6 +215,20 @@ class _HtmlEditorWidgetWebState extends State<HtmlEditorWidget> {
             """;
       }
     }
+
+    if (widget.htmlEditorOptions.normalizeHtmlTextWhenPasting) {
+      summernoteCallbacks =
+          '''$summernoteCallbacks        onPaste: function (e) {
+                const clipboardData = (e.originalEvent || e).clipboardData || window.clipboardData;
+                const htmlData = clipboardData.getData('text/html');
+                if (htmlData) {
+                  e.preventDefault();
+                  document.execCommand("insertHTML", false, htmlData);
+                }
+              },
+        ''';
+    }
+
     summernoteCallbacks = '$summernoteCallbacks}';
     var darkCSS = '';
     if ((Theme.of(widget.initBC).brightness == Brightness.dark ||

--- a/lib/src/widgets/html_editor_widget_web.dart
+++ b/lib/src/widgets/html_editor_widget_web.dart
@@ -276,6 +276,8 @@ class _HtmlEditorWidgetWebState extends State<HtmlEditorWidget> {
           \$('#summernote-2').on('summernote.focus', function() {
             editorHasBeenFocused = true;
           });
+          
+          ${widget.htmlEditorOptions.normalizeHtmlTextWhenDropping ? JavascriptUtils.jsHandleNormalizeHtmlTextWhenDropping: ''}
         });
        
         window.parent.addEventListener('message', handleMessage, false);

--- a/lib/utils/javascript_utils.dart
+++ b/lib/utils/javascript_utils.dart
@@ -270,4 +270,48 @@ class JavascriptUtils {
       \$('#summernote-2').summernote('pasteHTML', imgSource);
     }
   ''';
+
+  static const String jsHandleNormalizeHtmlTextWhenDropping = '''
+    let noteEditor = document.getElementsByClassName('note-editor')[0];
+    if (noteEditor) {
+      noteEditor.addEventListener("drop", function(event) {
+        let types = event.dataTransfer.types;
+        if (types.includes("text/html")) {
+          try {
+            const dataTransfer = (event.originalEvent || event).dataTransfer;
+            const htmlData = dataTransfer.getData('text/html');
+            if (!htmlData) return;
+             
+            event.preventDefault();
+            
+            const x = event.clientX;
+            const y = event.clientY;
+      
+            noteEditor.focus();
+      
+            let range;
+            if (document.caretRangeFromPoint) {
+              range = document.caretRangeFromPoint(x, y);
+            } else if (document.caretPositionFromPoint) {
+              const pos = document.caretPositionFromPoint(x, y);
+              range = document.createRange();
+              range.setStart(pos.offsetNode, pos.offset);
+            }
+      
+            if (range) {
+              const selection = window.getSelection();
+              selection.removeAllRanges();
+              selection.addRange(range);
+            }
+      
+            setTimeout(() => {
+              document.execCommand("insertHTML", false, htmlData);
+            }, 0);
+          } catch (error) {
+            console.error('[Drop Handler] Error during drop handling:', error);
+          }
+        }
+      });
+    }
+  ''';
 }

--- a/lib/utils/options.dart
+++ b/lib/utils/options.dart
@@ -30,6 +30,7 @@ class HtmlEditorOptions {
     this.disableDragAndDrop = false,
     this.cacheHTMLAssetOffline = false,
     this.normalizeHtmlTextWhenPasting = false,
+    this.normalizeHtmlTextWhenDropping = false,
   });
 
   /// The editor will automatically adjust its height when the keyboard is active
@@ -144,6 +145,9 @@ class HtmlEditorOptions {
 
   /// Normalize HTML text when pasting
   final bool normalizeHtmlTextWhenPasting;
+
+  /// Normalize HTML text when dropping
+  final bool normalizeHtmlTextWhenDropping;
 }
 
 /// Options that modify the toolbar and its behavior

--- a/lib/utils/options.dart
+++ b/lib/utils/options.dart
@@ -29,6 +29,7 @@ class HtmlEditorOptions {
     this.customInternalCSS = '',
     this.disableDragAndDrop = false,
     this.cacheHTMLAssetOffline = false,
+    this.normalizeHtmlTextWhenPasting = false,
   });
 
   /// The editor will automatically adjust its height when the keyboard is active
@@ -140,6 +141,9 @@ class HtmlEditorOptions {
 
   /// Inject JS/CSS content directly into HTML to support loading assets when in offline mode
   final bool cacheHTMLAssetOffline;
+
+  /// Normalize HTML text when pasting
+  final bool normalizeHtmlTextWhenPasting;
 }
 
 /// Options that modify the toolbar and its behavior

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: html_editor_enhanced
 description: HTML rich text editor for Android, iOS, and Web, using the Summernote library.
   Enhanced with highly customizable widget-based controls, bug fixes, callbacks, dark mode, and more.
-version: 3.2.1
+version: 3.2.2
 homepage: https://github.com/tneotia/html-editor-enhanced
 
 environment:


### PR DESCRIPTION
## Issue

On some browsers, especially chromium-based browsers, every time you copy & paste or drag & drop text from an `odt` file, the `line-height` automatically changes to `1px`.

## Reproduce



https://github.com/user-attachments/assets/cb1346cf-4a24-4104-87a6-a87768e63af4


## Related 

https://github.com/summernote/summernote/issues/3983

## Root cause

The content when copied or dragged from the odt file does not have `line-height=1px`. But when inserted into the summernote editor it automatically changes to `line-height=1px`. There is no code in the project that makes this change, so it could be the browser's javascript code or the summernote library that does this automatically.

## Solution

Normalize HTML text when pasting and dropping


## Resolved


https://github.com/user-attachments/assets/905769b6-30ba-4c43-88da-d111f6f79547

