### PR TITLE
fix(editor): intercept Ctrl+K shortcut to open custom link overlay

### DIFF
--- a/lib/src/widgets/html_editor_widget_web.dart
+++ b/lib/src/widgets/html_editor_widget_web.dart
@@ -318,6 +318,7 @@ class _HtmlEditorWidgetWebState extends State<HtmlEditorWidget> {
           ${widget.htmlEditorOptions.normalizeHtmlTextWhenDropping ? JavascriptUtils.jsHandleNormalizeHtmlTextWhenDropping : ''}
           
           ${widget.htmlEditorOptions.useLinkTooltipOverlay ? JavascriptUtils.jsHandleClickHyperLink(createdViewId) : ''}
+          ${widget.htmlEditorOptions.useLinkTooltipOverlay ? JavascriptUtils.jsHandleCtrlKShortcutForInsertLink(createdViewId) : ''}
         });
        
         window.parent.addEventListener('message', handleMessage, false);

--- a/lib/utils/javascript_utils.dart
+++ b/lib/utils/javascript_utils.dart
@@ -580,10 +580,10 @@ class JavascriptUtils {
   /// by [HtmlEditorOptions.useLinkTooltipOverlay]).
   static String jsHandleCtrlKShortcutForInsertLink(String viewId) => '''
     \$('#summernote-2').on('summernote.keydown', function(_, e) {
-      const isMac = navigator.platform.toUpperCase().indexOf('MAC') !== -1;
+      const isMac = /mac/i.test(navigator.userAgentData?.platform ?? navigator.platform);
       const isLinkShortcut = isMac
-        ? e.metaKey && !e.ctrlKey && !e.altKey && e.keyCode === 75
-        : e.ctrlKey && !e.metaKey && !e.altKey && e.keyCode === 75;
+        ? e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey && e.code === 'KeyK'
+        : e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey && e.code === 'KeyK';
 
       if (isLinkShortcut) {
         e.preventDefault();

--- a/lib/utils/javascript_utils.dart
+++ b/lib/utils/javascript_utils.dart
@@ -562,4 +562,42 @@ class JavascriptUtils {
       }
     }
   ''';
+
+  /// Intercepts the platform-correct link shortcut inside the Summernote editor
+  /// and redirects it to the custom Flutter link-insertion overlay instead of
+  /// Summernote's built-in link dialog.
+  ///
+  /// Uses the same Mac-detection heuristic as Summernote itself so the trigger
+  /// mirrors the active keyMap entry:
+  ///   • macOS  → Cmd+K  (metaKey only)
+  ///   • others → Ctrl+K (ctrlKey only)
+  ///
+  /// Calling [e.preventDefault()] causes Summernote to skip its own
+  /// `handleKeyMap` step, so the native dialog is never opened.
+  ///
+  /// [getCaretRect] is always available when this handler is injected because
+  /// [jsFunctionUpdateOrInsertLink] is injected at the same time (both guarded
+  /// by [HtmlEditorOptions.useLinkTooltipOverlay]).
+  static String jsHandleCtrlKShortcutForInsertLink(String viewId) => '''
+    \$('#summernote-2').on('summernote.keydown', function(_, e) {
+      const isMac = navigator.platform.toUpperCase().indexOf('MAC') !== -1;
+      const isLinkShortcut = isMac
+        ? e.metaKey && !e.ctrlKey && !e.altKey && e.keyCode === 75
+        : e.ctrlKey && !e.metaKey && !e.altKey && e.keyCode === 75;
+
+      if (isLinkShortcut) {
+        e.preventDefault();
+        try {
+          const rect = getCaretRect();
+          const selectedText = window.getSelection().toString();
+          window.parent.postMessage(JSON.stringify({
+            "view": "$viewId",
+            "type": "toDart: openInsertLinkDialog",
+            "rect": rect,
+            "text": selectedText
+          }), "*");
+        } catch (_) {}
+      }
+    });
+  ''';
 }


### PR DESCRIPTION
## Issue
Summernote's default keyMap maps `Ctrl+K` / `Cmd+K` to `linkDialog.show`, which opens its own native modal. This dialog bypasses the custom `LinkEditDialogOverlay` already used for link-click editing.

## Solution
Add `jsHandleCtrlKShortcutForInsertLink` in `JavascriptUtils`, injected inside `$(document).ready` when `useLinkTooltipOverlay` is `true`.

When `Ctrl+K` / `Cmd+K` is pressed:
1. `e.preventDefault()` stops Summernote from running `handleKeyMap` → native dialog never opens.
2. Caret rect and selected text are posted to Flutter as `toDart: openInsertLinkDialog` → the existing custom overlay is shown, identical to the toolbar link button flow.